### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cable
 
 [![readme style: standard][readme style standard badge]][standard readme]
+[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/ethereum/cable/badge)](https://www.gitpoap.io/gh/ethereum/cable)
 
 > Cable: CMake Bootstrap Library
 


### PR DESCRIPTION
Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie